### PR TITLE
Add Configuration and ConfigurationInitializer to read YAML

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,19 +1,11 @@
 plugins {
-    id 'java'
     id 'application'
     id 'org.graalvm.buildtools.native' version '0.9.23'
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation 'com.beust:jcommander:1.82'
-
-    testImplementation platform("org.junit:junit-bom:5.9.3")
-    testImplementation "org.junit.jupiter:junit-jupiter"
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    implementation project(':configuration')
 }
 
 java {

--- a/app/src/main/java/org/abelsromero/demo/App.java
+++ b/app/src/main/java/org/abelsromero/demo/App.java
@@ -5,6 +5,8 @@ package org.abelsromero.demo;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.UnixStyleUsageFormatter;
+import org.abelsromero.demo.config.Configuration;
+import org.abelsromero.demo.config.ConfigurationInitializer;
 
 public class App {
 
@@ -17,9 +19,42 @@ public class App {
             jc.setUsageFormatter(new UnixStyleUsageFormatter(jc));
             jc.usage();
         } else {
+            System.out.println("----");
+            final Configuration config = readConfiguration(options);
+            System.out.println(config);
+
+            // TODO pass Configuration instead of options
             System.out.println(new Greeter(options).getMessage());
             if (options.isDebug() && !options.getParameters().isEmpty())
                 System.out.println("Ignored parameters: " + options.getParameters());
         }
+    }
+
+    // TODO merge options correctly
+    private static Configuration readConfiguration(Options options) {
+        boolean uppercase = false;
+        boolean lowercase = false;
+        int repeat = 1;
+        if (!isEmpty(options.getConfig())) {
+            Configuration candidate = ConfigurationInitializer.init(options.getConfig());
+            // no need else, already false by default
+            if (candidate.uppercase()) {
+                uppercase = true;
+            }
+            if (candidate.lowercase()) {
+                lowercase = true;
+            }
+            if (candidate.repeat() > 0) {
+                repeat = candidate.repeat();
+            } else {
+                repeat = options.getRepeat();
+            }
+        }
+        return new Configuration(uppercase, lowercase, repeat);
+    }
+
+
+    private static boolean isEmpty(String value) {
+        return value == null || value.length() == 0;
     }
 }

--- a/app/src/main/java/org/abelsromero/demo/App.java
+++ b/app/src/main/java/org/abelsromero/demo/App.java
@@ -7,7 +7,8 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.UnixStyleUsageFormatter;
 import org.abelsromero.demo.config.Configuration;
 import org.abelsromero.demo.config.ConfigurationInitializer;
-import org.abelsromero.demo.config.LetterCase;
+
+import static org.abelsromero.demo.CliOptionsMerger.merge;
 
 
 public class App {
@@ -31,8 +32,6 @@ public class App {
         }
     }
 
-    // TODO merge options correctly
-    // TODO test merging
     private static Configuration readConfiguration(CliOptions options) {
         var configuration = merge(Configuration.defaultConfiguration(), options);
 
@@ -41,21 +40,8 @@ public class App {
 
             // TODO fail if lower and upper are set at the same time
             return configuration.merge(candidate);
-        } else {
-            return configuration;
         }
-    }
 
-    private static Configuration merge(Configuration configuration, CliOptions options) {
-        if (options.isUppercase()) {
-            configuration.setLetterCase(LetterCase.UPPER);
-        }
-        if (options.isLowercase()) {
-            configuration.setLetterCase(LetterCase.LOWER);
-        }
-        if (options.getRepeat() > 0) {
-            configuration.setRepeat(options.getRepeat());
-        }
         return configuration;
     }
 

--- a/app/src/main/java/org/abelsromero/demo/App.java
+++ b/app/src/main/java/org/abelsromero/demo/App.java
@@ -21,13 +21,12 @@ public class App {
             jc.setUsageFormatter(new UnixStyleUsageFormatter(jc));
             jc.usage();
         } else {
-            System.out.println("----");
             final Configuration config = readConfiguration(options);
-            System.out.println(config);
+            if (config.isDebug())
+                System.out.println(config);
 
-            // TODO pass Configuration instead of options
-            System.out.println(new Greeter(options).getMessage());
-            if (options.isDebug() && !options.getParameters().isEmpty())
+            System.out.println(new Greeter(options.getName(), config).getMessage());
+            if (config.isDebug() && !options.getParameters().isEmpty())
                 System.out.println("Ignored parameters: " + options.getParameters());
         }
     }
@@ -37,8 +36,9 @@ public class App {
     private static Configuration readConfiguration(CliOptions options) {
         var configuration = merge(Configuration.defaultConfiguration(), options);
 
-        if (!isEmpty(options.getConfig())) {
-            var candidate = ConfigurationInitializer.init(options.getConfig());
+        if (!isEmpty(options.getConfigFile())) {
+            var candidate = ConfigurationInitializer.load(options.getConfigFile());
+
             // TODO fail if lower and upper are set at the same time
             return configuration.merge(candidate);
         } else {

--- a/app/src/main/java/org/abelsromero/demo/App.java
+++ b/app/src/main/java/org/abelsromero/demo/App.java
@@ -7,12 +7,14 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.UnixStyleUsageFormatter;
 import org.abelsromero.demo.config.Configuration;
 import org.abelsromero.demo.config.ConfigurationInitializer;
+import org.abelsromero.demo.config.LetterCase;
+
 
 public class App {
 
     public static void main(String[] args) {
-        final Options options = new Options();
-        final JCommander jc = new OptionsParser()
+        final CliOptions options = new CliOptions();
+        final JCommander jc = new CliOptionsParser()
                 .parse(options, args);
 
         if (options.isHelp()) {
@@ -31,28 +33,31 @@ public class App {
     }
 
     // TODO merge options correctly
-    private static Configuration readConfiguration(Options options) {
-        boolean uppercase = false;
-        boolean lowercase = false;
-        int repeat = 1;
+    // TODO test merging
+    private static Configuration readConfiguration(CliOptions options) {
+        var configuration = merge(Configuration.defaultConfiguration(), options);
+
         if (!isEmpty(options.getConfig())) {
-            Configuration candidate = ConfigurationInitializer.init(options.getConfig());
-            // no need else, already false by default
-            if (candidate.uppercase()) {
-                uppercase = true;
-            }
-            if (candidate.lowercase()) {
-                lowercase = true;
-            }
-            if (candidate.repeat() > 0) {
-                repeat = candidate.repeat();
-            } else {
-                repeat = options.getRepeat();
-            }
+            var candidate = ConfigurationInitializer.init(options.getConfig());
+            // TODO fail if lower and upper are set at the same time
+            return configuration.merge(candidate);
+        } else {
+            return configuration;
         }
-        return new Configuration(uppercase, lowercase, repeat);
     }
 
+    private static Configuration merge(Configuration configuration, CliOptions options) {
+        if (options.isUppercase()) {
+            configuration.setLetterCase(LetterCase.UPPER);
+        }
+        if (options.isLowercase()) {
+            configuration.setLetterCase(LetterCase.LOWER);
+        }
+        if (options.getRepeat() > 0) {
+            configuration.setRepeat(options.getRepeat());
+        }
+        return configuration;
+    }
 
     private static boolean isEmpty(String value) {
         return value == null || value.length() == 0;

--- a/app/src/main/java/org/abelsromero/demo/App.java
+++ b/app/src/main/java/org/abelsromero/demo/App.java
@@ -7,6 +7,7 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.UnixStyleUsageFormatter;
 import org.abelsromero.demo.config.Configuration;
 import org.abelsromero.demo.config.ConfigurationInitializer;
+import org.abelsromero.demo.config.ConfigurationValidator;
 
 import static org.abelsromero.demo.CliOptionsMerger.merge;
 
@@ -23,8 +24,6 @@ public class App {
             jc.usage();
         } else {
             final Configuration config = readConfiguration(options);
-            if (config.isDebug())
-                System.out.println(config);
 
             System.out.println(new Greeter(options.getName(), config).getMessage());
             if (config.isDebug() && !options.getParameters().isEmpty())
@@ -37,8 +36,12 @@ public class App {
 
         if (!isEmpty(options.getConfigFile())) {
             var candidate = ConfigurationInitializer.load(options.getConfigFile());
+            if (options.isDebug())
+                System.out.println(candidate);
 
-            // TODO fail if lower and upper are set at the same time
+            new ConfigurationValidator()
+                    .validate(candidate);
+
             return configuration.merge(candidate);
         }
 

--- a/app/src/main/java/org/abelsromero/demo/CliOptions.java
+++ b/app/src/main/java/org/abelsromero/demo/CliOptions.java
@@ -6,7 +6,7 @@ import com.beust.jcommander.validators.PositiveInteger;
 import java.util.ArrayList;
 import java.util.List;
 
-final class Options {
+final class CliOptions {
 
     @Parameter
     private List<String> parameters = new ArrayList<>();
@@ -30,7 +30,7 @@ final class Options {
     private boolean help = false;
 
     // TODO Integrate correctly
-    @Parameter(names = {"-c"}, hidden = true, description = "Configuration file path", order = 4)
+    @Parameter(names = {"-c", "--config-file"}, hidden = true, description = "Configuration file path", order = 4)
     private String config;
 
     public List<String> getParameters() {

--- a/app/src/main/java/org/abelsromero/demo/CliOptions.java
+++ b/app/src/main/java/org/abelsromero/demo/CliOptions.java
@@ -31,7 +31,7 @@ final class CliOptions {
 
     // TODO Integrate correctly
     @Parameter(names = {"-c", "--config-file"}, hidden = true, description = "Configuration file path", order = 4)
-    private String config;
+    private String configFile;
 
     public List<String> getParameters() {
         return parameters;
@@ -61,7 +61,7 @@ final class CliOptions {
         return help;
     }
 
-    public String getConfig() {
-        return config;
+    public String getConfigFile() {
+        return configFile;
     }
 }

--- a/app/src/main/java/org/abelsromero/demo/CliOptions.java
+++ b/app/src/main/java/org/abelsromero/demo/CliOptions.java
@@ -29,7 +29,6 @@ final class CliOptions {
     @Parameter(names = {"-h", "--help"}, help = true, description = "Show this message", order = 6)
     private boolean help = false;
 
-    // TODO Integrate correctly
     @Parameter(names = {"-c", "--config-file"}, hidden = true, description = "Configuration file path", order = 4)
     private String configFile;
 

--- a/app/src/main/java/org/abelsromero/demo/CliOptionsMerger.java
+++ b/app/src/main/java/org/abelsromero/demo/CliOptionsMerger.java
@@ -1,0 +1,26 @@
+package org.abelsromero.demo;
+
+import org.abelsromero.demo.config.Configuration;
+import org.abelsromero.demo.config.LetterCase;
+
+final class CliOptionsMerger {
+
+    private CliOptionsMerger() {
+    }
+
+    static Configuration merge(Configuration configuration, CliOptions options) {
+        if (options.isUppercase()) {
+            configuration.setLetterCase(LetterCase.UPPER);
+        }
+        if (options.isLowercase()) {
+            configuration.setLetterCase(LetterCase.LOWER);
+        }
+        if (options.getRepeat() > 0) {
+            configuration.setRepeat(options.getRepeat());
+        }
+
+        configuration.setDebug(options.isDebug());
+
+        return configuration;
+    }
+}

--- a/app/src/main/java/org/abelsromero/demo/CliOptionsParser.java
+++ b/app/src/main/java/org/abelsromero/demo/CliOptionsParser.java
@@ -2,9 +2,9 @@ package org.abelsromero.demo;
 
 import com.beust.jcommander.JCommander;
 
-public class OptionsParser {
+public class CliOptionsParser {
 
-    public JCommander parse(Options options, String[] args) {
+    public JCommander parse(CliOptions options, String[] args) {
         final JCommander jc = JCommander.newBuilder()
                 .addObject(options)
                 .build();

--- a/app/src/main/java/org/abelsromero/demo/Greeter.java
+++ b/app/src/main/java/org/abelsromero/demo/Greeter.java
@@ -1,5 +1,7 @@
 package org.abelsromero.demo;
 
+import org.abelsromero.demo.config.Configuration;
+
 import java.util.StringJoiner;
 
 public class Greeter {
@@ -8,15 +10,14 @@ public class Greeter {
 
     private final String message;
 
-    Greeter(CliOptions options) {
-        String message = TEMPLATE.formatted(options.getName());
-        if (options.isUppercase()) {
-            message = message.toUpperCase();
-        } else if (options.isLowercase()) {
-            message = message.toLowerCase();
-        }
+    Greeter(String name, Configuration options) {
+        final String message = switch (options.getLetterCase()) {
+            case UPPER -> TEMPLATE.formatted(name).toUpperCase();
+            case LOWER -> TEMPLATE.formatted(name).toLowerCase();
+            case NONE -> TEMPLATE.formatted(name);
+        };
 
-        StringJoiner stringJoiner = new StringJoiner("\n");
+        final StringJoiner stringJoiner = new StringJoiner("\n");
         for (int i = 0; i < options.getRepeat(); i++) {
             stringJoiner.add(message);
         }

--- a/app/src/main/java/org/abelsromero/demo/Greeter.java
+++ b/app/src/main/java/org/abelsromero/demo/Greeter.java
@@ -8,7 +8,7 @@ public class Greeter {
 
     private final String message;
 
-    Greeter(Options options) {
+    Greeter(CliOptions options) {
         String message = TEMPLATE.formatted(options.getName());
         if (options.isUppercase()) {
             message = message.toUpperCase();

--- a/app/src/main/java/org/abelsromero/demo/Options.java
+++ b/app/src/main/java/org/abelsromero/demo/Options.java
@@ -29,6 +29,10 @@ final class Options {
     @Parameter(names = {"-h", "--help"}, help = true, description = "Show this message", order = 6)
     private boolean help = false;
 
+    // TODO Integrate correctly
+    @Parameter(names = {"-c"}, hidden = true, description = "Configuration file path", order = 4)
+    private String config;
+
     public List<String> getParameters() {
         return parameters;
     }
@@ -55,5 +59,9 @@ final class Options {
 
     public boolean isHelp() {
         return help;
+    }
+
+    public String getConfig() {
+        return config;
     }
 }

--- a/app/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/app/src/main/resources/META-INF/native-image/reflect-config.json
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "name": "org.abelsromero.demo.Options",
+    "name": "org.abelsromero.demo.CliOptions",
     "allDeclaredFields": true,
     "queryAllDeclaredMethods": true
   },

--- a/app/src/test/java/org/abelsromero/demo/AppTest.java
+++ b/app/src/test/java/org/abelsromero/demo/AppTest.java
@@ -1,12 +1,20 @@
 package org.abelsromero.demo;
 
+import com.beust.jcommander.ParameterException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class AppTest {
 
@@ -35,5 +43,28 @@ public class AppTest {
         assertThat(outputLines[5]).contains("-r, --repeat");
         assertThat(outputLines[6]).contains("--debug");
         assertThat(outputLines[7]).contains("-h, --help");
+    }
+
+    @Test
+    void shouldFailWhenAParameterIsInvalid() {
+        assertThatThrownBy(() -> App.main(new String[]{"-r", "-1"}))
+                .isInstanceOf(ParameterException.class);
+    }
+
+    @Test
+    void shouldFailWhenRepeatIsOverriddenFromConfigWithAnInvalidValue(@TempDir Path tempDir) throws IOException {
+        final Path configFile = createConfigFile(tempDir, """
+                config:
+                  repeat: -2
+                """);
+
+        assertThatThrownBy(() -> App.main(new String[]{"-n", "test", "-r", "2", "-c", configFile.toAbsolutePath().toString()}))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static Path createConfigFile(Path tempDir, String config) throws IOException {
+        final Path configFile = Files.createFile(tempDir.resolve(String.format("full-config-%s.yaml", UUID.randomUUID())));
+        Files.writeString(configFile, config);
+        return configFile;
     }
 }

--- a/app/src/test/java/org/abelsromero/demo/AppTest.java
+++ b/app/src/test/java/org/abelsromero/demo/AppTest.java
@@ -1,6 +1,8 @@
 package org.abelsromero.demo;
 
 import com.beust.jcommander.ParameterException;
+import org.abelsromero.demo.test.FilesHandler;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -9,14 +11,22 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class AppTest {
+
+    @TempDir
+    private static Path tempDir;
+
+    private static FilesHandler filesHandler;
+
+    @BeforeAll
+    static void setup() {
+        filesHandler = new FilesHandler(tempDir);
+    }
 
     @ParameterizedTest
     @ValueSource(strings = {"-h", "--help"})
@@ -52,19 +62,13 @@ public class AppTest {
     }
 
     @Test
-    void shouldFailWhenRepeatIsOverriddenFromConfigWithAnInvalidValue(@TempDir Path tempDir) throws IOException {
-        final Path configFile = createConfigFile(tempDir, """
+    void shouldFailWhenRepeatIsOverriddenFromConfigWithAnInvalidValue() throws IOException {
+        final Path configFile = filesHandler.createFile("""
                 config:
                   repeat: -2
                 """);
 
         assertThatThrownBy(() -> App.main(new String[]{"-n", "test", "-r", "2", "-c", configFile.toAbsolutePath().toString()}))
                 .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    private static Path createConfigFile(Path tempDir, String config) throws IOException {
-        final Path configFile = Files.createFile(tempDir.resolve(String.format("full-config-%s.yaml", UUID.randomUUID())));
-        Files.writeString(configFile, config);
-        return configFile;
     }
 }

--- a/app/src/test/java/org/abelsromero/demo/CliOptionsMergerTest.java
+++ b/app/src/test/java/org/abelsromero/demo/CliOptionsMergerTest.java
@@ -1,0 +1,71 @@
+package org.abelsromero.demo;
+
+import org.abelsromero.demo.config.Configuration;
+import org.abelsromero.demo.config.LetterCase;
+import org.junit.jupiter.api.Test;
+
+import static org.abelsromero.demo.CliOptionsMerger.merge;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CliOptionsMergerTest {
+
+    @Test
+    void shouldReturnDefaultConfiguration() {
+        final var config = Configuration.defaultConfiguration();
+        final var option = ReflectionMock.mock(new CliOptions());
+
+        Configuration configuration = merge(config, option.getInstance());
+
+        assertConfiguration(configuration, LetterCase.NONE, 1, false);
+    }
+
+    @Test
+    void shouldMergeUpperCase() {
+        final var config = Configuration.defaultConfiguration();
+        final var option = ReflectionMock.mock(new CliOptions());
+        option.mockBoolean("uppercase", true);
+
+        Configuration configuration = merge(config, option.getInstance());
+
+        assertConfiguration(configuration, LetterCase.UPPER, 1, false);
+    }
+
+    @Test
+    void shouldMergeLowerCase() {
+        final var config = Configuration.defaultConfiguration();
+        final var option = ReflectionMock.mock(new CliOptions());
+        option.mockBoolean("lowercase", true);
+
+        Configuration configuration = merge(config, option.getInstance());
+
+        assertConfiguration(configuration, LetterCase.LOWER, 1, false);
+    }
+
+    @Test
+    void shouldMergeRepeat() {
+        final var config = Configuration.defaultConfiguration();
+        final var option = ReflectionMock.mock(new CliOptions());
+        option.mockInteger("repeat", 8);
+
+        Configuration configuration = merge(config, option.getInstance());
+
+        assertConfiguration(configuration, LetterCase.NONE, 8, false);
+    }
+
+    @Test
+    void shouldMergeDebug() {
+        final var config = Configuration.defaultConfiguration();
+        final var option = ReflectionMock.mock(new CliOptions());
+        option.mockBoolean("debug", true);
+
+        Configuration configuration = merge(config, option.getInstance());
+
+        assertConfiguration(configuration, LetterCase.NONE, 1, true);
+    }
+
+    private static void assertConfiguration(Configuration configuration, LetterCase letterCase, int repeat, boolean debug) {
+        assertThat(configuration.getLetterCase()).isEqualTo(letterCase);
+        assertThat(configuration.getRepeat()).isEqualTo(repeat);
+        assertThat(configuration.isDebug()).isEqualTo(debug);
+    }
+}

--- a/app/src/test/java/org/abelsromero/demo/CliOptionsMergerTest.java
+++ b/app/src/test/java/org/abelsromero/demo/CliOptionsMergerTest.java
@@ -2,6 +2,7 @@ package org.abelsromero.demo;
 
 import org.abelsromero.demo.config.Configuration;
 import org.abelsromero.demo.config.LetterCase;
+import org.abelsromero.demo.test.ReflectionMock;
 import org.junit.jupiter.api.Test;
 
 import static org.abelsromero.demo.CliOptionsMerger.merge;

--- a/app/src/test/java/org/abelsromero/demo/CliOptionsParserTest.java
+++ b/app/src/test/java/org/abelsromero/demo/CliOptionsParserTest.java
@@ -81,7 +81,7 @@ class CliOptionsParserTest {
         new CliOptionsParser()
                 .parse(options, minimalArgs(option, "my-settings.yaml"));
 
-        assertThat(options.getConfig()).isEqualTo("my-settings.yaml");
+        assertThat(options.getConfigFile()).isEqualTo("my-settings.yaml");
     }
 
     private String[] minimalArgs(String... values) {

--- a/app/src/test/java/org/abelsromero/demo/CliOptionsParserTest.java
+++ b/app/src/test/java/org/abelsromero/demo/CliOptionsParserTest.java
@@ -12,21 +12,21 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
-class OptionsParserTest {
+class CliOptionsParserTest {
 
     @Test
     void shouldFailWhenNoArgsArePassed() {
-        final Options options = new Options();
+        final CliOptions options = new CliOptions();
 
-        Throwable throwable = catchThrowable(() -> new OptionsParser().parse(options, new String[]{}));
+        Throwable throwable = catchThrowable(() -> new CliOptionsParser().parse(options, new String[]{}));
 
         assertThat(throwable).isInstanceOf(ParameterException.class);
     }
 
     @Test
     void shouldParseName() {
-        final Options options = new Options();
-        new OptionsParser()
+        final CliOptions options = new CliOptions();
+        new CliOptionsParser()
                 .parse(options, new String[]{"-n", "Arthur"});
 
         assertThat(options.getName()).isEqualTo("Arthur");
@@ -37,8 +37,8 @@ class OptionsParserTest {
 
         @Test
         void shouldParseShortOption() {
-            final Options options = new Options();
-            new OptionsParser()
+            final CliOptions options = new CliOptions();
+            new CliOptionsParser()
                     .parse(options, minimalArgs("-u"));
 
             assertThat(options.isUppercase()).isTrue();
@@ -46,8 +46,8 @@ class OptionsParserTest {
 
         @Test
         void shouldParseLongOption() {
-            final Options options = new Options();
-            new OptionsParser()
+            final CliOptions options = new CliOptions();
+            new CliOptionsParser()
                     .parse(options, minimalArgs("--uppercase"));
 
             assertThat(options.isUppercase()).isTrue();
@@ -57,8 +57,8 @@ class OptionsParserTest {
     @ParameterizedTest
     @ValueSource(strings = {"-l", "--lowercase"})
     void shouldParseLowercaseOption(String option) {
-        final Options options = new Options();
-        new OptionsParser()
+        final CliOptions options = new CliOptions();
+        new CliOptionsParser()
                 .parse(options, minimalArgs(option));
 
         assertThat(options.isLowercase()).isTrue();
@@ -67,11 +67,21 @@ class OptionsParserTest {
     @ParameterizedTest
     @ValueSource(strings = {"-r", "--repeat"})
     void shouldParseRepeatOption(String option) {
-        final Options options = new Options();
-        new OptionsParser()
+        final CliOptions options = new CliOptions();
+        new CliOptionsParser()
                 .parse(options, minimalArgs(option, "4"));
 
         assertThat(options.getRepeat()).isEqualTo(4);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"-c", "--config-file"})
+    void shouldParseConfigFileOption(String option) {
+        final CliOptions options = new CliOptions();
+        new CliOptionsParser()
+                .parse(options, minimalArgs(option, "my-settings.yaml"));
+
+        assertThat(options.getConfig()).isEqualTo("my-settings.yaml");
     }
 
     private String[] minimalArgs(String... values) {

--- a/app/src/test/java/org/abelsromero/demo/GreeterTest.java
+++ b/app/src/test/java/org/abelsromero/demo/GreeterTest.java
@@ -45,9 +45,9 @@ class GreeterTest {
         assertThat(message).isEqualTo("Hello Arthur!!\n" + "Hello Arthur!!\n" + "Hello Arthur!!\n" + "Hello Arthur!!");
     }
 
-    public static ReflectionMock<Options> options() {
-        final Options options = new Options();
-        final ReflectionMock<Options> mock = ReflectionMock.mock(options);
+    public static ReflectionMock<CliOptions> options() {
+        final CliOptions options = new CliOptions();
+        final ReflectionMock<CliOptions> mock = ReflectionMock.mock(options);
         mock.mockString("name", "Arthur");
         return mock;
     }

--- a/app/src/test/java/org/abelsromero/demo/GreeterTest.java
+++ b/app/src/test/java/org/abelsromero/demo/GreeterTest.java
@@ -1,54 +1,60 @@
 package org.abelsromero.demo;
 
+import org.abelsromero.demo.config.Configuration;
+import org.abelsromero.demo.config.LetterCase;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class GreeterTest {
 
+    private static final String NAME = "Arthur";
+
     @Test
     void shouldGreet() {
-        final var options = options();
+        final var config = Configuration.defaultConfiguration();
 
-        final String message = new Greeter(options.getInstance()).getMessage();
+        final String message = new Greeter(NAME, config).getMessage();
 
         assertThat(message).isEqualTo("Hello Arthur!!");
     }
 
     @Test
     void shouldGreetInUppercase() {
-        final var options = options();
-        options.mockBoolean("uppercase", Boolean.TRUE);
+        final var config = configuration(LetterCase.UPPER);
 
-        final String message = new Greeter(options.getInstance()).getMessage();
+        final String message = new Greeter(NAME, config).getMessage();
 
         assertThat(message).isEqualTo("HELLO ARTHUR!!");
     }
 
     @Test
     void shouldGreetInLowercase() {
-        final var options = options();
-        options.mockBoolean("lowercase", Boolean.TRUE);
+        final var config = configuration(LetterCase.LOWER);
 
-        final String message = new Greeter(options.getInstance()).getMessage();
+        final String message = new Greeter(NAME, config).getMessage();
 
         assertThat(message).isEqualTo("hello arthur!!");
     }
 
     @Test
     void shouldGreetWithRepeats() {
-        final var options = options();
-        options.mockInteger("repeat", 4);
+        final var config = configuration(4);
 
-        final String message = new Greeter(options.getInstance()).getMessage();
+        final String message = new Greeter(NAME, config).getMessage();
 
         assertThat(message).isEqualTo("Hello Arthur!!\n" + "Hello Arthur!!\n" + "Hello Arthur!!\n" + "Hello Arthur!!");
     }
 
-    public static ReflectionMock<CliOptions> options() {
-        final CliOptions options = new CliOptions();
-        final ReflectionMock<CliOptions> mock = ReflectionMock.mock(options);
-        mock.mockString("name", "Arthur");
-        return mock;
+    public static Configuration configuration(LetterCase letterCase) {
+        Configuration configuration = new Configuration();
+        configuration.setLetterCase(letterCase);
+        return configuration;
+    }
+
+    public static Configuration configuration(int repeat) {
+        Configuration configuration = new Configuration();
+        configuration.setRepeat(repeat);
+        return configuration;
     }
 }

--- a/app/src/test/java/org/abelsromero/demo/ReflectionMock.java
+++ b/app/src/test/java/org/abelsromero/demo/ReflectionMock.java
@@ -12,7 +12,7 @@ class ReflectionMock<T> {
         this.clazz = (Class<T>) instance.getClass();
     }
 
-    static <T> ReflectionMock<T> mock(Object clazz) {
+    static <T> ReflectionMock<T> mock(T clazz) {
         return new ReflectionMock<>(clazz);
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ subprojects {
     }
 
     dependencies {
+        testImplementation project(':test-tools')
         testImplementation platform("org.junit:junit-bom:5.9.3")
         testImplementation "org.junit.jupiter:junit-jupiter"
         testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,23 @@
+subprojects {
+    apply plugin: 'java'
+
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        testImplementation platform("org.junit:junit-bom:5.9.3")
+        testImplementation "org.junit.jupiter:junit-jupiter"
+        testImplementation 'org.assertj:assertj-core:3.24.2'
+    }
+
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(17)
+        }
+    }
+
+    tasks.named('test') {
+        useJUnitPlatform()
+    }
+}

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,3 @@
+config:
+  uppercase: true
+  repeat: 1

--- a/configuration/build.gradle
+++ b/configuration/build.gradle
@@ -1,5 +1,3 @@
-
 dependencies {
     implementation 'org.yaml:snakeyaml:2.0'
 }
-

--- a/configuration/build.gradle
+++ b/configuration/build.gradle
@@ -1,0 +1,5 @@
+
+dependencies {
+    implementation 'org.yaml:snakeyaml:2.0'
+}
+

--- a/configuration/src/main/java/org/abelsromero/demo/config/Configuration.java
+++ b/configuration/src/main/java/org/abelsromero/demo/config/Configuration.java
@@ -1,0 +1,4 @@
+package org.abelsromero.demo.config;
+
+public record Configuration(Boolean uppercase, Boolean lowercase, Integer repeat) {
+}

--- a/configuration/src/main/java/org/abelsromero/demo/config/Configuration.java
+++ b/configuration/src/main/java/org/abelsromero/demo/config/Configuration.java
@@ -1,4 +1,43 @@
 package org.abelsromero.demo.config;
 
-public record Configuration(Boolean uppercase, Boolean lowercase, Integer repeat) {
+/**
+ * Note: Mutable Pojo to allow modification since the final configuration is the merge of
+ * the yaml and terminal inputs.
+ * It doesn't make it easier with snakeyml, since snakeyml does not support enums.
+ */
+public class Configuration {
+
+    private LetterCase letterCase;
+    private Integer repeat;
+
+    public static Configuration defaultConfiguration() {
+        var configuration = new Configuration();
+        configuration.letterCase = LetterCase.NONE;
+        configuration.repeat = 1;
+        return configuration;
+    }
+
+    public void setLetterCase(LetterCase letterCase) {
+        this.letterCase = letterCase;
+    }
+
+    public void setRepeat(Integer repeat) {
+        this.repeat = repeat;
+    }
+
+    public LetterCase getLetterCase() {
+        return letterCase;
+    }
+
+    public Integer getRepeat() {
+        return repeat;
+    }
+
+    public Configuration merge(Configuration configuration) {
+        if (configuration.letterCase != null)
+            this.letterCase = configuration.letterCase;
+        if (configuration.repeat != null)
+            this.repeat = configuration.repeat;
+        return this;
+    }
 }

--- a/configuration/src/main/java/org/abelsromero/demo/config/Configuration.java
+++ b/configuration/src/main/java/org/abelsromero/demo/config/Configuration.java
@@ -1,5 +1,7 @@
 package org.abelsromero.demo.config;
 
+import java.util.Objects;
+
 /**
  * Note: Mutable Pojo to allow modification since the final configuration is the merge of
  * the yaml and terminal inputs.
@@ -7,37 +9,53 @@ package org.abelsromero.demo.config;
  */
 public class Configuration {
 
-    private LetterCase letterCase;
-    private Integer repeat;
+    private LetterCase letterCase = LetterCase.NONE;
+    private Integer repeat = 1;
+    private boolean debug = false;
 
     public static Configuration defaultConfiguration() {
-        var configuration = new Configuration();
-        configuration.letterCase = LetterCase.NONE;
-        configuration.repeat = 1;
-        return configuration;
+        return new Configuration();
     }
 
     public void setLetterCase(LetterCase letterCase) {
+        Objects.nonNull(letterCase);
         this.letterCase = letterCase;
-    }
-
-    public void setRepeat(Integer repeat) {
-        this.repeat = repeat;
     }
 
     public LetterCase getLetterCase() {
         return letterCase;
     }
 
+    public void setRepeat(Integer repeat) {
+        this.repeat = repeat;
+    }
+
     public Integer getRepeat() {
         return repeat;
     }
 
+    public boolean isDebug() {
+        return debug;
+    }
+
+    public void setDebug(boolean debug) {
+        this.debug = debug;
+    }
+
     public Configuration merge(Configuration configuration) {
-        if (configuration.letterCase != null)
-            this.letterCase = configuration.letterCase;
-        if (configuration.repeat != null)
-            this.repeat = configuration.repeat;
+        this.letterCase = configuration.letterCase;
+        this.repeat = configuration.repeat;
+        this.debug = configuration.debug;
         return this;
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder()
+                .append("Configuration:")
+                .append(String.format("\tLetterCase: %s\n", letterCase))
+                .append(String.format("\tRepeat: %s\n", repeat))
+                .append(String.format("\tDebug: %s\n", debug))
+                .toString();
     }
 }

--- a/configuration/src/main/java/org/abelsromero/demo/config/ConfigurationInitializer.java
+++ b/configuration/src/main/java/org/abelsromero/demo/config/ConfigurationInitializer.java
@@ -26,13 +26,21 @@ public class ConfigurationInitializer {
 
         final Map<String, Object> data = yaml.load(fileReader);
         if (data == null)
-            return new Configuration(Boolean.FALSE, Boolean.FALSE, 1);
+            return Configuration.defaultConfiguration();
 
-        Map<String, Object> configNode = (Map<String, Object>) data.getOrDefault("config", Map.of());
-        return new Configuration(
-                (Boolean) configNode.getOrDefault("uppercase", Boolean.FALSE),
-                (Boolean) configNode.getOrDefault("lowercase", Boolean.FALSE),
-                (Integer) configNode.getOrDefault("repeat", 1)
-        );
+        final var configNode = (Map<String, Object>) data.getOrDefault("config", Map.of());
+
+        final var configuration = new Configuration();
+        configuration.setLetterCase(letterCase((String) configNode.get("letter-case")));
+        configuration.setRepeat((Integer) configNode.getOrDefault("repeat", 1));
+
+        return configuration;
+    }
+
+    private static LetterCase letterCase(String value) {
+        if (value == null || value.length() == 0)
+            return LetterCase.NONE;
+        else
+            return LetterCase.valueOf(value.toUpperCase());
     }
 }

--- a/configuration/src/main/java/org/abelsromero/demo/config/ConfigurationInitializer.java
+++ b/configuration/src/main/java/org/abelsromero/demo/config/ConfigurationInitializer.java
@@ -14,7 +14,7 @@ public class ConfigurationInitializer {
 
     }
 
-    public static Configuration init(String filePath) {
+    public static Configuration load(String filePath) {
 
         final Yaml yaml = new Yaml();
         final FileReader fileReader;

--- a/configuration/src/main/java/org/abelsromero/demo/config/ConfigurationInitializer.java
+++ b/configuration/src/main/java/org/abelsromero/demo/config/ConfigurationInitializer.java
@@ -1,0 +1,38 @@
+package org.abelsromero.demo.config;
+
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.util.Map;
+
+// TODO non-zero positive validation for repeat
+// TODO consolidate case options in an enum
+public class ConfigurationInitializer {
+
+    private ConfigurationInitializer() {
+
+    }
+
+    public static Configuration init(String filePath) {
+
+        final Yaml yaml = new Yaml();
+        final FileReader fileReader;
+        try {
+            fileReader = new FileReader(filePath);
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+
+        final Map<String, Object> data = yaml.load(fileReader);
+        if (data == null)
+            return new Configuration(Boolean.FALSE, Boolean.FALSE, 1);
+
+        Map<String, Object> configNode = (Map<String, Object>) data.getOrDefault("config", Map.of());
+        return new Configuration(
+                (Boolean) configNode.getOrDefault("uppercase", Boolean.FALSE),
+                (Boolean) configNode.getOrDefault("lowercase", Boolean.FALSE),
+                (Integer) configNode.getOrDefault("repeat", 1)
+        );
+    }
+}

--- a/configuration/src/main/java/org/abelsromero/demo/config/ConfigurationInitializer.java
+++ b/configuration/src/main/java/org/abelsromero/demo/config/ConfigurationInitializer.java
@@ -7,7 +7,6 @@ import java.io.FileReader;
 import java.util.Map;
 
 // TODO non-zero positive validation for repeat
-// TODO consolidate case options in an enum
 public class ConfigurationInitializer {
 
     private ConfigurationInitializer() {

--- a/configuration/src/main/java/org/abelsromero/demo/config/ConfigurationValidator.java
+++ b/configuration/src/main/java/org/abelsromero/demo/config/ConfigurationValidator.java
@@ -1,0 +1,9 @@
+package org.abelsromero.demo.config;
+
+public class ConfigurationValidator {
+
+    public void validate(Configuration configuration) throws IllegalArgumentException {
+        if (configuration.getRepeat() <= 0)
+            throw new IllegalArgumentException("Invalid repeat value: " + configuration.getRepeat());
+    }
+}

--- a/configuration/src/main/java/org/abelsromero/demo/config/LetterCase.java
+++ b/configuration/src/main/java/org/abelsromero/demo/config/LetterCase.java
@@ -1,0 +1,7 @@
+package org.abelsromero.demo.config;
+
+public enum LetterCase {
+    LOWER,
+    UPPER,
+    NONE
+}

--- a/configuration/src/test/java/org/abelsromero/demo/config/ConfigurationInitializerTest.java
+++ b/configuration/src/test/java/org/abelsromero/demo/config/ConfigurationInitializerTest.java
@@ -1,0 +1,59 @@
+package org.abelsromero.demo.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfigurationInitializerTest {
+
+
+    @Test
+    void shouldReadEmptyConfiguration(@TempDir Path tempDir) throws IOException {
+        final Path emptyFile = Files.createFile(tempDir.resolve("empty-config.yaml"));
+
+        Configuration init = ConfigurationInitializer.init(emptyFile.toAbsolutePath().toString());
+
+        assertThat(init)
+                .isEqualTo(new Configuration(false, false, 1));
+    }
+
+    @Test
+    void shouldReadFullConfiguration(@TempDir Path tempDir) throws IOException {
+        final Path configFile = createConfigFile(tempDir, """
+                config:
+                  uppercase: true
+                  lowercase: true
+                  repeat: 8
+                """);
+
+        Configuration init = ConfigurationInitializer.init(configFile.toAbsolutePath().toString());
+
+        assertThat(init)
+                .isEqualTo(new Configuration(true, true, 8));
+    }
+
+    @Test
+    void shouldReadPartialConfiguration(@TempDir Path tempDir) throws IOException {
+        final Path configFile = createConfigFile(tempDir, """
+                config:
+                  uppercase: true
+                  repeat: 1
+                """);
+
+        Configuration init = ConfigurationInitializer.init(configFile.toAbsolutePath().toString());
+
+        assertThat(init)
+                .isEqualTo(new Configuration(true, false, 1));
+    }
+
+    private static Path createConfigFile(Path tempDir, String config) throws IOException {
+        final Path configFile = Files.createFile(tempDir.resolve("full-config.yaml"));
+        Files.writeString(configFile, config);
+        return configFile;
+    }
+}

--- a/configuration/src/test/java/org/abelsromero/demo/config/ConfigurationInitializerTest.java
+++ b/configuration/src/test/java/org/abelsromero/demo/config/ConfigurationInitializerTest.java
@@ -11,44 +11,96 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ConfigurationInitializerTest {
 
+    @TempDir
+    private Path tempDir;
 
     @Test
-    void shouldReadEmptyConfiguration(@TempDir Path tempDir) throws IOException {
+    void shouldReadEmptyConfiguration() throws IOException {
         final Path emptyFile = Files.createFile(tempDir.resolve("empty-config.yaml"));
 
         Configuration init = ConfigurationInitializer.init(emptyFile.toAbsolutePath().toString());
 
         assertThat(init)
-                .isEqualTo(new Configuration(false, false, 1));
+                .usingRecursiveComparison()
+                .isEqualTo(configuration(LetterCase.NONE, 1));
     }
 
     @Test
-    void shouldReadFullConfiguration(@TempDir Path tempDir) throws IOException {
+    void shouldReadFullConfiguration() throws IOException {
         final Path configFile = createConfigFile(tempDir, """
                 config:
-                  uppercase: true
-                  lowercase: true
+                  letter-case: upper
                   repeat: 8
                 """);
 
-        Configuration init = ConfigurationInitializer.init(configFile.toAbsolutePath().toString());
+        Configuration config = ConfigurationInitializer.init(configFile.toAbsolutePath().toString());
 
-        assertThat(init)
-                .isEqualTo(new Configuration(true, true, 8));
+        assertThat(config)
+                .usingRecursiveComparison()
+                .isEqualTo(configuration(LetterCase.UPPER, 8));
     }
 
     @Test
-    void shouldReadPartialConfiguration(@TempDir Path tempDir) throws IOException {
+    void shouldReadUppercaseConfiguration() throws IOException {
         final Path configFile = createConfigFile(tempDir, """
                 config:
-                  uppercase: true
-                  repeat: 1
+                  letter-case: upper
                 """);
 
-        Configuration init = ConfigurationInitializer.init(configFile.toAbsolutePath().toString());
+        Configuration config = ConfigurationInitializer.init(configFile.toAbsolutePath().toString());
 
-        assertThat(init)
-                .isEqualTo(new Configuration(true, false, 1));
+        assertThat(config)
+                .usingRecursiveComparison()
+                .isEqualTo(configuration(LetterCase.UPPER, 1));
+    }
+
+    @Test
+    void shouldReadLowercaseConfiguration() throws IOException {
+        final Path configFile = createConfigFile(tempDir, """
+                config:
+                  letter-case: lower
+                """);
+
+        Configuration config = ConfigurationInitializer.init(configFile.toAbsolutePath().toString());
+
+        assertThat(config)
+                .usingRecursiveComparison()
+                .isEqualTo(configuration(LetterCase.LOWER, 1));
+    }
+
+    @Test
+    void shouldReadNonecaseConfiguration() throws IOException {
+        final Path configFile = createConfigFile(tempDir, """
+                config:
+                  letter-case: none
+                """);
+
+        Configuration config = ConfigurationInitializer.init(configFile.toAbsolutePath().toString());
+
+        assertThat(config)
+                .usingRecursiveComparison()
+                .isEqualTo(configuration(LetterCase.NONE, 1));
+    }
+
+    @Test
+    void shouldReadRepeatConfiguration() throws IOException {
+        final Path configFile = createConfigFile(tempDir, """
+                config:
+                  repeat: 42
+                """);
+
+        Configuration config = ConfigurationInitializer.init(configFile.toAbsolutePath().toString());
+
+        assertThat(config)
+                .usingRecursiveComparison()
+                .isEqualTo(configuration(LetterCase.NONE, 42));
+    }
+
+    private Object configuration(LetterCase letterCase, int repeat) {
+        final var config = new Configuration();
+        config.setLetterCase(letterCase);
+        config.setRepeat(repeat);
+        return config;
     }
 
     private static Path createConfigFile(Path tempDir, String config) throws IOException {

--- a/configuration/src/test/java/org/abelsromero/demo/config/ConfigurationInitializerTest.java
+++ b/configuration/src/test/java/org/abelsromero/demo/config/ConfigurationInitializerTest.java
@@ -18,7 +18,7 @@ class ConfigurationInitializerTest {
     void shouldReadEmptyConfiguration() throws IOException {
         final Path emptyFile = Files.createFile(tempDir.resolve("empty-config.yaml"));
 
-        Configuration init = ConfigurationInitializer.init(emptyFile.toAbsolutePath().toString());
+        Configuration init = ConfigurationInitializer.load(emptyFile.toAbsolutePath().toString());
 
         assertThat(init)
                 .usingRecursiveComparison()
@@ -33,7 +33,7 @@ class ConfigurationInitializerTest {
                   repeat: 8
                 """);
 
-        Configuration config = ConfigurationInitializer.init(configFile.toAbsolutePath().toString());
+        Configuration config = ConfigurationInitializer.load(configFile.toAbsolutePath().toString());
 
         assertThat(config)
                 .usingRecursiveComparison()
@@ -47,7 +47,7 @@ class ConfigurationInitializerTest {
                   letter-case: upper
                 """);
 
-        Configuration config = ConfigurationInitializer.init(configFile.toAbsolutePath().toString());
+        Configuration config = ConfigurationInitializer.load(configFile.toAbsolutePath().toString());
 
         assertThat(config)
                 .usingRecursiveComparison()
@@ -61,7 +61,7 @@ class ConfigurationInitializerTest {
                   letter-case: lower
                 """);
 
-        Configuration config = ConfigurationInitializer.init(configFile.toAbsolutePath().toString());
+        Configuration config = ConfigurationInitializer.load(configFile.toAbsolutePath().toString());
 
         assertThat(config)
                 .usingRecursiveComparison()
@@ -75,7 +75,7 @@ class ConfigurationInitializerTest {
                   letter-case: none
                 """);
 
-        Configuration config = ConfigurationInitializer.init(configFile.toAbsolutePath().toString());
+        Configuration config = ConfigurationInitializer.load(configFile.toAbsolutePath().toString());
 
         assertThat(config)
                 .usingRecursiveComparison()
@@ -89,7 +89,7 @@ class ConfigurationInitializerTest {
                   repeat: 42
                 """);
 
-        Configuration config = ConfigurationInitializer.init(configFile.toAbsolutePath().toString());
+        Configuration config = ConfigurationInitializer.load(configFile.toAbsolutePath().toString());
 
         assertThat(config)
                 .usingRecursiveComparison()

--- a/configuration/src/test/java/org/abelsromero/demo/config/ConfigurationInitializerTest.java
+++ b/configuration/src/test/java/org/abelsromero/demo/config/ConfigurationInitializerTest.java
@@ -1,25 +1,34 @@
 package org.abelsromero.demo.config;
 
+import org.abelsromero.demo.test.FilesHandler;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.UUID;
 
+import static org.abelsromero.demo.config.ConfigurationInitializer.load;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ConfigurationInitializerTest {
 
     @TempDir
-    private Path tempDir;
+    private static Path tempDir;
+
+    private static FilesHandler filesHandler;
+
+    @BeforeAll
+    static void setup() {
+        filesHandler = new FilesHandler(tempDir);
+    }
 
     @Test
     void shouldReadEmptyConfiguration() throws IOException {
         final Path emptyFile = Files.createFile(tempDir.resolve("empty-config.yaml"));
 
-        Configuration init = ConfigurationInitializer.load(emptyFile.toAbsolutePath().toString());
+        Configuration init = load(emptyFile.toAbsolutePath().toString());
 
         assertThat(init)
                 .usingRecursiveComparison()
@@ -28,13 +37,13 @@ class ConfigurationInitializerTest {
 
     @Test
     void shouldReadFullConfiguration() throws IOException {
-        final Path configFile = createConfigFile(tempDir, """
+        final Path configFile = filesHandler.createFile("""
                 config:
                   letter-case: upper
                   repeat: 8
                 """);
 
-        Configuration config = ConfigurationInitializer.load(configFile.toAbsolutePath().toString());
+        Configuration config = load(configFile.toAbsolutePath().toString());
 
         assertThat(config)
                 .usingRecursiveComparison()
@@ -43,12 +52,12 @@ class ConfigurationInitializerTest {
 
     @Test
     void shouldReadUppercaseConfiguration() throws IOException {
-        final Path configFile = createConfigFile(tempDir, """
+        final Path configFile = filesHandler.createFile("""
                 config:
                   letter-case: upper
                 """);
 
-        Configuration config = ConfigurationInitializer.load(configFile.toAbsolutePath().toString());
+        Configuration config = load(configFile.toAbsolutePath().toString());
 
         assertThat(config)
                 .usingRecursiveComparison()
@@ -57,12 +66,12 @@ class ConfigurationInitializerTest {
 
     @Test
     void shouldReadLowercaseConfiguration() throws IOException {
-        final Path configFile = createConfigFile(tempDir, """
+        final Path configFile = filesHandler.createFile("""
                 config:
                   letter-case: lower
                 """);
 
-        Configuration config = ConfigurationInitializer.load(configFile.toAbsolutePath().toString());
+        Configuration config = load(configFile.toAbsolutePath().toString());
 
         assertThat(config)
                 .usingRecursiveComparison()
@@ -71,12 +80,12 @@ class ConfigurationInitializerTest {
 
     @Test
     void shouldReadNonecaseConfiguration() throws IOException {
-        final Path configFile = createConfigFile(tempDir, """
+        final Path configFile = filesHandler.createFile("""
                 config:
                   letter-case: none
                 """);
 
-        Configuration config = ConfigurationInitializer.load(configFile.toAbsolutePath().toString());
+        Configuration config = load(configFile.toAbsolutePath().toString());
 
         assertThat(config)
                 .usingRecursiveComparison()
@@ -85,12 +94,12 @@ class ConfigurationInitializerTest {
 
     @Test
     void shouldReadRepeatConfiguration() throws IOException {
-        final Path configFile = createConfigFile(tempDir, """
+        final Path configFile = filesHandler.createFile("""
                 config:
                   repeat: 42
                 """);
 
-        Configuration config = ConfigurationInitializer.load(configFile.toAbsolutePath().toString());
+        Configuration config = load(configFile.toAbsolutePath().toString());
 
         assertThat(config)
                 .usingRecursiveComparison()
@@ -102,11 +111,5 @@ class ConfigurationInitializerTest {
         config.setLetterCase(letterCase);
         config.setRepeat(repeat);
         return config;
-    }
-
-    private static Path createConfigFile(Path tempDir, String config) throws IOException {
-        final Path configFile = Files.createFile(tempDir.resolve(String.format("full-config-%s.yaml", UUID.randomUUID())));
-        Files.writeString(configFile, config);
-        return configFile;
     }
 }

--- a/configuration/src/test/java/org/abelsromero/demo/config/ConfigurationInitializerTest.java
+++ b/configuration/src/test/java/org/abelsromero/demo/config/ConfigurationInitializerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -104,7 +105,7 @@ class ConfigurationInitializerTest {
     }
 
     private static Path createConfigFile(Path tempDir, String config) throws IOException {
-        final Path configFile = Files.createFile(tempDir.resolve("full-config.yaml"));
+        final Path configFile = Files.createFile(tempDir.resolve(String.format("full-config-%s.yaml", UUID.randomUUID())));
         Files.writeString(configFile, config);
         return configFile;
     }

--- a/configuration/src/test/java/org/abelsromero/demo/config/ConfigurationTest.java
+++ b/configuration/src/test/java/org/abelsromero/demo/config/ConfigurationTest.java
@@ -1,5 +1,6 @@
 package org.abelsromero.demo.config;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/configuration/src/test/java/org/abelsromero/demo/config/ConfigurationTest.java
+++ b/configuration/src/test/java/org/abelsromero/demo/config/ConfigurationTest.java
@@ -10,7 +10,7 @@ class ConfigurationTest {
     void shouldReturnDefaultConfiguration() {
         final Configuration configuration = Configuration.defaultConfiguration();
 
-        assertConfiguration(configuration, LetterCase.NONE, 1);
+        assertConfiguration(configuration, LetterCase.NONE, 1, false);
     }
 
     @Test
@@ -20,7 +20,7 @@ class ConfigurationTest {
 
         configuration.merge(toMerge);
 
-        assertConfiguration(configuration, LetterCase.NONE, 1);
+        assertConfiguration(configuration, LetterCase.NONE, 1, false);
     }
 
     @Test
@@ -31,7 +31,7 @@ class ConfigurationTest {
 
         configuration.merge(toMerge);
 
-        assertConfiguration(configuration, LetterCase.UPPER, 1);
+        assertConfiguration(configuration, LetterCase.UPPER, 1, false);
     }
 
     @Test
@@ -42,11 +42,23 @@ class ConfigurationTest {
 
         configuration.merge(toMerge);
 
-        assertConfiguration(configuration, LetterCase.NONE, 42);
+        assertConfiguration(configuration, LetterCase.NONE, 42, false);
     }
 
-    private static void assertConfiguration(Configuration configuration, LetterCase letterCase, int repeat) {
+    @Test
+    void shouldMergeDebug() {
+        final Configuration configuration = Configuration.defaultConfiguration();
+        final Configuration toMerge = Configuration.defaultConfiguration();
+        toMerge.setDebug(true);
+
+        configuration.merge(toMerge);
+
+        assertConfiguration(configuration, LetterCase.NONE, 1, true);
+    }
+
+    private static void assertConfiguration(Configuration configuration, LetterCase letterCase, int repeat, boolean debug) {
         assertThat(configuration.getLetterCase()).isEqualTo(letterCase);
         assertThat(configuration.getRepeat()).isEqualTo(repeat);
+        assertThat(configuration.isDebug()).isEqualTo(debug);
     }
 }

--- a/configuration/src/test/java/org/abelsromero/demo/config/ConfigurationTest.java
+++ b/configuration/src/test/java/org/abelsromero/demo/config/ConfigurationTest.java
@@ -1,0 +1,52 @@
+package org.abelsromero.demo.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfigurationTest {
+
+    @Test
+    void shouldReturnDefaultConfiguration() {
+        final Configuration configuration = Configuration.defaultConfiguration();
+
+        assertConfiguration(configuration, LetterCase.NONE, 1);
+    }
+
+    @Test
+    void shouldMergeTheSameConfiguration() {
+        final Configuration configuration = Configuration.defaultConfiguration();
+        final Configuration toMerge = Configuration.defaultConfiguration();
+
+        configuration.merge(toMerge);
+
+        assertConfiguration(configuration, LetterCase.NONE, 1);
+    }
+
+    @Test
+    void shouldMergeLetterCase() {
+        final Configuration configuration = Configuration.defaultConfiguration();
+        final Configuration toMerge = Configuration.defaultConfiguration();
+        toMerge.setLetterCase(LetterCase.UPPER);
+
+        configuration.merge(toMerge);
+
+        assertConfiguration(configuration, LetterCase.UPPER, 1);
+    }
+
+    @Test
+    void shouldMergeRepeat() {
+        final Configuration configuration = Configuration.defaultConfiguration();
+        final Configuration toMerge = Configuration.defaultConfiguration();
+        toMerge.setRepeat(42);
+
+        configuration.merge(toMerge);
+
+        assertConfiguration(configuration, LetterCase.NONE, 42);
+    }
+
+    private static void assertConfiguration(Configuration configuration, LetterCase letterCase, int repeat) {
+        assertThat(configuration.getLetterCase()).isEqualTo(letterCase);
+        assertThat(configuration.getRepeat()).isEqualTo(repeat);
+    }
+}

--- a/configuration/src/test/java/org/abelsromero/demo/config/ConfigurationValidatorTest.java
+++ b/configuration/src/test/java/org/abelsromero/demo/config/ConfigurationValidatorTest.java
@@ -1,0 +1,43 @@
+package org.abelsromero.demo.config;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ConfigurationValidatorTest {
+
+    final ConfigurationValidator validator = new ConfigurationValidator();
+
+    @Nested
+    class ShouldPass {
+        @Test
+        void whenConfigurationIsValid() {
+            validator.validate(new Configuration());
+        }
+    }
+
+    @Nested
+    class ShouldFail {
+
+        @Test
+        void whenRepeatIs0() {
+            final var configuration = new Configuration();
+            configuration.setRepeat(0);
+
+            assertThatThrownBy(() -> validator.validate(configuration))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Invalid repeat value: 0");
+        }
+
+        @Test
+        void whenRepeatIsNegative() {
+            final var configuration = new Configuration();
+            configuration.setRepeat(-1);
+
+            assertThatThrownBy(() -> validator.validate(configuration))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Invalid repeat value: -1");
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,4 +7,4 @@ pluginManagement {
 
 rootProject.name = 'java-plain-native'
 
-include('app', 'configuration')
+include('app', 'configuration', 'test-tools')

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,4 +7,4 @@ pluginManagement {
 
 rootProject.name = 'java-plain-native'
 
-include('app')
+include('app', 'configuration')

--- a/test-tools/src/main/java/org/abelsromero/demo/test/FilesHandler.java
+++ b/test-tools/src/main/java/org/abelsromero/demo/test/FilesHandler.java
@@ -1,0 +1,20 @@
+package org.abelsromero.demo.test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.UUID;
+
+public final class FilesHandler {
+
+    final Path tempDir;
+
+    public FilesHandler(Path tempDir) {
+        this.tempDir = tempDir;
+    }
+
+    public Path createFile(String content) throws IOException {
+        final Path configFile = java.nio.file.Files.createFile(tempDir.resolve(String.format("full-config-%s.yaml", UUID.randomUUID())));
+        java.nio.file.Files.writeString(configFile, content);
+        return configFile;
+    }
+}

--- a/test-tools/src/main/java/org/abelsromero/demo/test/ReflectionMock.java
+++ b/test-tools/src/main/java/org/abelsromero/demo/test/ReflectionMock.java
@@ -1,8 +1,8 @@
-package org.abelsromero.demo;
+package org.abelsromero.demo.test;
 
 import java.lang.reflect.Field;
 
-class ReflectionMock<T> {
+public class ReflectionMock<T> {
 
     private final Object instance;
     private final Class<T> clazz;
@@ -12,11 +12,11 @@ class ReflectionMock<T> {
         this.clazz = (Class<T>) instance.getClass();
     }
 
-    static <T> ReflectionMock<T> mock(T clazz) {
+    public static <T> ReflectionMock<T> mock(T clazz) {
         return new ReflectionMock<>(clazz);
     }
 
-    void mockBoolean(String field, Boolean value) {
+    public void mockBoolean(String field, Boolean value) {
         setValue(field, value);
     }
 
@@ -38,7 +38,7 @@ class ReflectionMock<T> {
         }
     }
 
-    T getInstance() {
+    public T getInstance() {
         return (T) instance;
     }
 }


### PR DESCRIPTION
Still WIP, but right now we can already read configurations from a YAML file.

* Create `configuration` module
* Unify Gradle common configuration in root `build.gradle.

:smiley: Snakeyaml has full support for native compilation, no especial actions were required.