### PR TITLE
User Gradle java-library instead of java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 subprojects {
-  apply plugin: 'java'
+  apply plugin: 'java-library'
 
   repositories {
     mavenCentral()


### PR DESCRIPTION
Adds 'api' configuration to better handle transitive dependencies.


PS: Because I know, at some point in the future I'd be wondering why 'api' is not working or why I can't use transitives libraries :sweat: 