### PR TITLE
Bump and update coordinates for JCommander v2.0

### DIFF
--- a/java-modules/cli-args-jcommander/build.gradle
+++ b/java-modules/cli-args-jcommander/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
   implementation project(':java-modules:cli-args-api')
-  implementation 'com.beust:jcommander:1.82'
+  implementation 'org.jcommander:jcommander:2.0'
 }
 
 graalvmNative {


### PR DESCRIPTION
Reachable metadata is still necessary.