### PR TITLE
Add option to format output as JSON

### DIFF
--- a/cli/java/build.gradle
+++ b/cli/java/build.gradle
@@ -8,6 +8,7 @@ dependencies {
   implementation project(':java-modules:cli-args-jcommander')
   implementation project(':java-modules:configuration')
   implementation project(':java-modules:logging-api')
+  implementation project(':java-modules:output-formatting')
   if (project.properties.getOrDefault('appLogger', 'stdout') == 'slf4j') {
     implementation project(':java-modules:logging-slf4j')
   }

--- a/cli/java/src/main/java/org/abelsromero/demo/App.java
+++ b/cli/java/src/main/java/org/abelsromero/demo/App.java
@@ -6,6 +6,7 @@ import org.abelsromero.demo.cli.impl.JCommanderOptionsHandler;
 import org.abelsromero.demo.config.Configuration;
 import org.abelsromero.demo.config.ConfigurationInitializer;
 import org.abelsromero.demo.config.ConfigurationValidator;
+import org.abelsromero.demo.json.MessageFormatter;
 import org.abelsromero.demo.logging.LoggingService;
 import org.abelsromero.demo.logging.LoggingServiceLocator;
 
@@ -27,7 +28,11 @@ public class App {
         final Configuration config = readConfiguration(options);
 
         final LoggingService innerLogger = new LoggingServiceLocator().locate(App.class);
-        innerLogger.info(new Greeter(options.getName(), config).getMessage());
+
+        String message = new Greeter(options.getName(), config).getMessage();
+        message = new MessageFormatter().format(message, options.getOutputFormat());
+
+        innerLogger.info(message);
         if (config.isDebug() && !options.getParameters().isEmpty())
             innerLogger.info("Ignored parameters: " + options.getParameters());
     }

--- a/cli/java/src/main/java/org/abelsromero/demo/Greeter.java
+++ b/cli/java/src/main/java/org/abelsromero/demo/Greeter.java
@@ -2,32 +2,20 @@ package org.abelsromero.demo;
 
 import org.abelsromero.demo.config.Configuration;
 
-import java.util.Locale;
 import java.util.StringJoiner;
 
-public class Greeter {
+class Greeter {
 
     private static final String TEMPLATE = "Hello %s!!";
 
     private final String message;
 
     Greeter(String name, Configuration options) {
-        /* java 17+
         final String message = switch (options.getLetterCase()) {
             case UPPER -> TEMPLATE.formatted(name).toUpperCase();
             case LOWER -> TEMPLATE.formatted(name).toLowerCase();
             case NONE -> TEMPLATE.formatted(name);
         };
-        */
-        String message = String.format(TEMPLATE, name);
-        switch (options.getLetterCase()) {
-            case UPPER:
-                message = message.toUpperCase(Locale.ROOT);
-                break;
-            case LOWER:
-                message = message.toLowerCase(Locale.ROOT);
-                break;
-        }
 
         final StringJoiner stringJoiner = new StringJoiner("\n");
         for (int i = 0; i < options.getRepeat(); i++) {

--- a/cli/java/src/test/java/org/abelsromero/demo/AppTest.java
+++ b/cli/java/src/test/java/org/abelsromero/demo/AppTest.java
@@ -52,8 +52,9 @@ class AppTest {
         assertThat(outputLines[3]).contains("-u, --uppercase");
         assertThat(outputLines[4]).contains("-l, --lowercase");
         assertThat(outputLines[5]).contains("-r, --repeat");
-        assertThat(outputLines[6]).contains("--debug");
-        assertThat(outputLines[7]).contains("-h, --help");
+        assertThat(outputLines[6]).contains("-o, --output    Output format (default: text) (values: [text, json])");
+        assertThat(outputLines[7]).contains("--debug");
+        assertThat(outputLines[8]).contains("-h, --help");
     }
 
     @Test

--- a/java-modules/cli-args-api/src/main/java/org/abelsromero/demo/cli/CliOptions.java
+++ b/java-modules/cli-args-api/src/main/java/org/abelsromero/demo/cli/CliOptions.java
@@ -19,6 +19,8 @@ public interface CliOptions {
 
     boolean isDebug();
 
+    OutputFormat getOutputFormat();
+
     boolean isHelp();
 
     String getConfigFile();

--- a/java-modules/cli-args-api/src/main/java/org/abelsromero/demo/cli/OutputFormat.java
+++ b/java-modules/cli-args-api/src/main/java/org/abelsromero/demo/cli/OutputFormat.java
@@ -1,0 +1,12 @@
+package org.abelsromero.demo.cli;
+
+public enum OutputFormat {
+
+    TEXT, JSON;
+
+    @Override
+    public String toString() {
+        // to make JCommander print lower case values in help
+        return name().toLowerCase();
+    }
+}

--- a/java-modules/cli-args-api/src/test/java/org/abelsromero/demo/cli/CliOptionsMergerTest.java
+++ b/java-modules/cli-args-api/src/test/java/org/abelsromero/demo/cli/CliOptionsMergerTest.java
@@ -115,6 +115,11 @@ public class CliOptionsMergerTest {
         }
 
         @Override
+        public OutputFormat getOutputFormat() {
+            return null;
+        }
+
+        @Override
         public boolean isHelp() {
             return help;
         }

--- a/java-modules/cli-args-jcommander/src/main/java/org/abelsromero/demo/cli/impl/JCommanderOptions.java
+++ b/java-modules/cli-args-jcommander/src/main/java/org/abelsromero/demo/cli/impl/JCommanderOptions.java
@@ -3,6 +3,7 @@ package org.abelsromero.demo.cli.impl;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.validators.PositiveInteger;
 import org.abelsromero.demo.cli.CliOptions;
+import org.abelsromero.demo.cli.OutputFormat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,10 +25,13 @@ public final class JCommanderOptions implements CliOptions {
     @Parameter(names = {"-r", "--repeat"}, validateWith = PositiveInteger.class, description = "Greet many times", order = 4)
     private int repeat = 1;
 
-    @Parameter(names = "--debug", description = "Debug mode", order = 5)
+    @Parameter(names = {"-o", "--output"}, description = "Output format", order = 5)
+    private OutputFormat output = OutputFormat.TEXT;
+
+    @Parameter(names = "--debug", description = "Debug mode", order = 6)
     private boolean debug = false;
 
-    @Parameter(names = {"-h", "--help"}, help = true, description = "Show this message", order = 6)
+    @Parameter(names = {"-h", "--help"}, help = true, description = "Show this message", order = 7)
     private boolean help = false;
 
     @Parameter(names = {"-c", "--config-file"}, hidden = true, description = "Configuration file path", order = 4)
@@ -63,6 +67,10 @@ public final class JCommanderOptions implements CliOptions {
         return debug;
     }
 
+    @Override
+    public OutputFormat getOutputFormat() {
+        return output;
+    }
 
     @Override
     public boolean isHelp() {

--- a/java-modules/cli-args-jcommander/src/test/java/org/abelsromero/demo/cli/impl/JCommanderOptionsParserTest.java
+++ b/java-modules/cli-args-jcommander/src/test/java/org/abelsromero/demo/cli/impl/JCommanderOptionsParserTest.java
@@ -1,6 +1,6 @@
 package org.abelsromero.demo.cli.impl;
 
-import org.junit.jupiter.api.Nested;
+import org.abelsromero.demo.cli.OutputFormat;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -22,26 +22,14 @@ class JCommanderOptionsParserTest {
         assertThat(options.getName()).isEqualTo("Arthur");
     }
 
-    @Nested
-    class WhenParsingUppercaseOption {
+    @ParameterizedTest
+    @ValueSource(strings = {"-u", "--uppercase"})
+    void shouldParseUppercaseOption(String option) {
+        final JCommanderOptions options = new JCommanderOptions();
+        new JCommanderOptionsParser()
+                .parse(options, minimalArgs(option));
 
-        @Test
-        void shouldParseShortOption() {
-            final JCommanderOptions options = new JCommanderOptions();
-            new JCommanderOptionsParser()
-                    .parse(options, minimalArgs("-u"));
-
-            assertThat(options.isUppercase()).isTrue();
-        }
-
-        @Test
-        void shouldParseLongOption() {
-            final JCommanderOptions options = new JCommanderOptions();
-            new JCommanderOptionsParser()
-                    .parse(options, minimalArgs("--uppercase"));
-
-            assertThat(options.isUppercase()).isTrue();
-        }
+        assertThat(options.isUppercase()).isTrue();
     }
 
     @ParameterizedTest
@@ -62,6 +50,16 @@ class JCommanderOptionsParserTest {
                 .parse(options, minimalArgs(option, "4"));
 
         assertThat(options.getRepeat()).isEqualTo(4);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"-o", "--output"})
+    void shouldParseOutputFormat(String option) {
+        final JCommanderOptions options = new JCommanderOptions();
+        new JCommanderOptionsParser()
+            .parse(options, minimalArgs(option, "json"));
+
+        assertThat(options.getOutputFormat()).isEqualTo(OutputFormat.JSON);
     }
 
     @ParameterizedTest

--- a/java-modules/cli-args-picocli/src/main/java/org/abelsromero/demo/cli/impl/PicocliOptions.java
+++ b/java-modules/cli-args-picocli/src/main/java/org/abelsromero/demo/cli/impl/PicocliOptions.java
@@ -1,6 +1,7 @@
 package org.abelsromero.demo.cli.impl;
 
 import org.abelsromero.demo.cli.CliOptions;
+import org.abelsromero.demo.cli.OutputFormat;
 import picocli.CommandLine;
 
 import java.util.ArrayList;
@@ -23,10 +24,13 @@ public class PicocliOptions implements CliOptions {
     @CommandLine.Option(names = {"-r", "--repeat"}, description = "Greet many times", order = 4)
     private int repeat = 1;
 
-    @CommandLine.Option(names = "--debug", description = "Debug mode", order = 5)
+    @CommandLine.Option(names = {"-o", "--output"}, description = "Output format", order = 5)
+    private OutputFormat output = OutputFormat.TEXT;
+
+    @CommandLine.Option(names = "--debug", description = "Debug mode", order = 6)
     private boolean debug = false;
 
-    @CommandLine.Option(names = {"-h", "--help"}, usageHelp = true, description = "Show this message", order = 6)
+    @CommandLine.Option(names = {"-h", "--help"}, usageHelp = true, description = "Show this message", order = 7)
     private boolean help = false;
 
     @CommandLine.Option(names = {"-c", "--config-file"}, hidden = true, description = "Configuration file path", order = 4)
@@ -61,6 +65,11 @@ public class PicocliOptions implements CliOptions {
     @Override
     public boolean isDebug() {
         return debug;
+    }
+
+    @Override
+    public OutputFormat getOutputFormat() {
+        return output;
     }
 
     @Override

--- a/java-modules/cli-args-picocli/src/test/java/org/abelsromero/demo/cli/impl/PicocliOptionsHandlerTest.java
+++ b/java-modules/cli-args-picocli/src/test/java/org/abelsromero/demo/cli/impl/PicocliOptionsHandlerTest.java
@@ -2,6 +2,7 @@ package org.abelsromero.demo.cli.impl;
 
 import org.abelsromero.demo.cli.CliOptions;
 import org.abelsromero.demo.cli.CliOptionsHandler;
+import org.abelsromero.demo.cli.OutputFormat;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -69,28 +70,15 @@ class PicocliOptionsHandlerTest {
             assertThat(options.getName()).isEqualTo("Arthur");
         }
 
-        @Nested
-        class WhenParsingUppercaseOption {
+        @ParameterizedTest
+        @ValueSource(strings = {"-u", "--uppercase"})
+        void shouldParseUppercaseOption(String option) {
+            final CliOptionsHandler optionsHandler = new PicocliOptionsHandler();
+            final String[] args = minimalArgs(option);
 
-            @Test
-            void shouldParseShortOption() {
-                final CliOptionsHandler optionsHandler = new PicocliOptionsHandler();
-                final String[] args = minimalArgs("-u");
+            CliOptions options = optionsHandler.parse(args);
 
-                CliOptions options = optionsHandler.parse(args);
-
-                assertThat(options.isUppercase()).isTrue();
-            }
-
-            @Test
-            void shouldParseLongOption() {
-                final CliOptionsHandler optionsHandler = new PicocliOptionsHandler();
-                final String[] args = minimalArgs("--uppercase");
-
-                CliOptions options = optionsHandler.parse(args);
-
-                assertThat(options.isUppercase()).isTrue();
-            }
+            assertThat(options.isUppercase()).isTrue();
         }
 
         @ParameterizedTest
@@ -113,6 +101,17 @@ class PicocliOptionsHandlerTest {
             CliOptions options = optionsHandler.parse(args);
 
             assertThat(options.getRepeat()).isEqualTo(4);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-o", "--output"})
+        void shouldParseOutputFormat(String option) {
+            final CliOptionsHandler optionsHandler = new PicocliOptionsHandler();
+            final String[] args = minimalArgs(option, "json");
+
+            CliOptions options = optionsHandler.parse(args);
+
+            assertThat(options.getOutputFormat()).isEqualTo(OutputFormat.JSON);
         }
 
         @ParameterizedTest

--- a/java-modules/output-formatting/build.gradle
+++ b/java-modules/output-formatting/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+  implementation project(':java-modules:cli-args-api')
+  implementation("com.fasterxml.jackson.core:jackson-databind:2.18.3")
+}

--- a/java-modules/output-formatting/src/main/java/org/abelsromero/demo/json/JsonMessage.java
+++ b/java-modules/output-formatting/src/main/java/org/abelsromero/demo/json/JsonMessage.java
@@ -1,0 +1,4 @@
+package org.abelsromero.demo.json;
+
+public record JsonMessage(String message) {
+}

--- a/java-modules/output-formatting/src/main/java/org/abelsromero/demo/json/MessageFormatter.java
+++ b/java-modules/output-formatting/src/main/java/org/abelsromero/demo/json/MessageFormatter.java
@@ -1,0 +1,23 @@
+package org.abelsromero.demo.json;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.abelsromero.demo.cli.OutputFormat;
+
+public class MessageFormatter {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public String format(String message, OutputFormat outputFormat) {
+        return switch (outputFormat) {
+            case JSON -> {
+                try {
+                    yield objectMapper.writeValueAsString(new JsonMessage(message));
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            case TEXT -> message;
+        };
+    }
+}

--- a/java-modules/output-formatting/src/main/resources/native-image/reachability-metadata.json
+++ b/java-modules/output-formatting/src/main/resources/native-image/reachability-metadata.json
@@ -1,0 +1,14 @@
+{
+  "reflection": [
+    {
+      "type": "org.abelsromero.demo.json.JsonMessage",
+      "allDeclaredFields": true,
+      "methods": [
+        {
+          "name": "message",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ]
+}

--- a/java-modules/output-formatting/src/test/java/org/abelsromero/demo/json/MessageFormatterTest.java
+++ b/java-modules/output-formatting/src/test/java/org/abelsromero/demo/json/MessageFormatterTest.java
@@ -1,0 +1,28 @@
+package org.abelsromero.demo.json;
+
+import org.abelsromero.demo.cli.OutputFormat;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MessageFormatterTest {
+
+    @Test
+    void shouldFormatAsText() {
+        final MessageFormatter formatter = new MessageFormatter();
+
+        String message = formatter.format("Hello World", OutputFormat.TEXT);
+
+        assertThat(message).isEqualTo("Hello World");
+    }
+
+    @Test
+    void shouldFormatAsJson() {
+        final MessageFormatter formatter = new MessageFormatter();
+
+        String message = formatter.format("Hello World", OutputFormat.JSON);
+
+        assertThat(message).isEqualTo("{\"message\":\"Hello World\"}");
+    }
+
+}

--- a/java-modules/test-tools/src/main/java/org/abelsromero/demo/test/ReflectionMock.java
+++ b/java-modules/test-tools/src/main/java/org/abelsromero/demo/test/ReflectionMock.java
@@ -31,6 +31,10 @@ public class ReflectionMock<T> {
         setValue(field, value);
     }
 
+    public void mockValue(String field, Object value) {
+        setValue(field, value);
+    }
+
     private void setValue(String field, Object value) {
         try {
             final Field declaredField = clazz.getDeclaredField(field);
@@ -44,4 +48,5 @@ public class ReflectionMock<T> {
     public T getInstance() {
         return (T) instance;
     }
+
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,5 +19,6 @@ include \
   ':java-modules:configuration',
   ':java-modules:logging-api',
   ':java-modules:logging-slf4j',
+  ':java-modules:output-formatting',
   ':java-modules:process',
   ':java-modules:test-tools'


### PR DESCRIPTION
This is an example of JSON generation with Jackson, to showcase the reachability metadata required.
Note the reachability metadata uses the new format.